### PR TITLE
Use nbviewer to display the notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ pip install git+https://github.com/abey79/vsketch#egg=vsketch
 $ pip install git+https://github.com/marceloprates/prettymaps.git
 ```
 
-## Usage example (For more examples, see [this Jupyter Notebook](https://github.com/marceloprates/prettymaps/blob/main/notebooks/examples.ipynb)):
+## Usage example (For more examples, see [this Jupyter Notebook](https://nbviewer.jupyter.org/github/marceloprates/prettymaps/blob/main/notebooks/examples.ipynb)):
 
 ```python
 # Init matplotlib figure


### PR DESCRIPTION
Tried visualizing the notebook on GitHub, but GitHub usually fails to display large notebooks (or even small ones sometimes :man_shrugging: ). But since their docs [mention nbviewer too](https://docs.github.com/en/github/managing-files-in-a-repository/working-with-non-code-files/working-with-jupyter-notebook-files-on-github) it should be OK to link to the Jupyter side instead?

Great project by the way, valeu!

Bruno