### PR TITLE
Added buffer distance in get_streets()

### DIFF
--- a/prettymaps/fetch.py
+++ b/prettymaps/fetch.py
@@ -80,7 +80,7 @@ def get_geometries(perimeter = None, point = None, radius = None, tags = {}, per
     return geometries
 
 # Get streets
-def get_streets(perimeter = None, point = None, radius = None, layer = 'streets', width = 6, custom_filter = None, circle = True, dilate = 0):
+def get_streets(perimeter = None, point = None, radius = None, layer = 'streets', width = 6, custom_filter = None, buffer = 0,circle = True, dilate = 0):
 
     if layer == 'streets':
         layer = 'highway'
@@ -88,13 +88,13 @@ def get_streets(perimeter = None, point = None, radius = None, layer = 'streets'
     # Boundary defined by polygon (perimeter)
     if perimeter is not None:
         # Fetch streets data, project & convert to GDF
-        streets = ox.graph_from_polygon(unary_union(perimeter.geometry), custom_filter = custom_filter)
+        streets = ox.graph_from_polygon(unary_union(perimeter.geometry).buffer(buffer) if buffer > 0 else unary_union(perimeter.geometry), custom_filter = custom_filter)
         streets = ox.project_graph(streets)
         streets = ox.graph_to_gdfs(streets, nodes = False)
     # Boundary defined by polygon (perimeter)
     elif (point is not None) and (radius is not None):
         # Fetch streets data, save CRS & project
-        streets = ox.graph_from_point(point, dist = radius+dilate, custom_filter = custom_filter)
+        streets = ox.graph_from_point(point, dist = radius+dilate+buffer, custom_filter = custom_filter)
         crs = ox.graph_to_gdfs(streets, nodes = False).crs
         streets = ox.project_graph(streets)
         # Compute perimeter from point & CRS


### PR DESCRIPTION
I added a buffer distance in `get_streets()` to fetch streets that are not fully inside the perimeter.
If the streets are only partially inside the perimeter, in some cases they will not fully load and will be missing from the final plot, similar to the  `perimeter_tolerance` argument in `get_geometries()`. Here is my own example with a plot centered at `(34.12006,35.64311)`, with `radius = 650`, `circle: False`, `dilate: 100` (based on the Barcelona example):

- With buffer value 500
![jbeil_buffer](https://user-images.githubusercontent.com/45701489/130961059-d60ad20a-b2e3-4731-a39e-982a9c203cd3.png)
- Without a buffer
![jbeil](https://user-images.githubusercontent.com/45701489/130961089-4567a843-1dcd-41e1-928c-65c4e6ffd0f2.png)
The difference is in the roads on the top and bottom right. I can share the code used to generate this plot if needed.