### PR TITLE
Bug fix for when 'text' param is supplied

### DIFF
--- a/prettymaps/draw.py
+++ b/prettymaps/draw.py
@@ -258,7 +258,7 @@ def plot(
             fontfamily = (osm_credit['fontfamily'] if 'fontfamily' in osm_credit else 'Ubuntu Mono'),
             fontsize = (osm_credit['fontsize']*d if 'fontsize' in osm_credit else d),
             zorder = (osm_credit['zorder'] if 'zorder' in osm_credit else len(layers)+1),
-            **{k:v for k,v in osm_credit.items() if k not in ['x', 'y', 'fontfamily', 'fontsize', 'zorder']}
+            **{k:v for k,v in osm_credit.items() if k not in ['text', 'x', 'y', 'fontfamily', 'fontsize', 'zorder']}
         )
 
     # Return perimeter


### PR DESCRIPTION
When you give param `osm_credit` with `text` set, it didn't work properly. 

Example:
`osm_credit = {'x': .405, 'y': .68, 'color': '#2F3737', 'text': 'Some other text'}`

This PR fixes that