### PR TITLE
Best practice structure for imports

### DIFF
--- a/prettymaps/__init__.py
+++ b/prettymaps/__init__.py
@@ -1,3 +1,1 @@
-# Fetch & Draw
-from .draw import *
-from .fetch import *
+from .draw import plot

--- a/prettymaps/curved_text.py
+++ b/prettymaps/curved_text.py
@@ -1,8 +1,8 @@
-from matplotlib import pyplot as plt
-from matplotlib import patches
+import math
+
 from matplotlib import text as mtext
 import numpy as np
-import math
+
 
 class CurvedText(mtext.Text):
     """

--- a/prettymaps/draw.py
+++ b/prettymaps/draw.py
@@ -1,32 +1,18 @@
-# OpenStreetMap Networkx library to download data from OpenStretMap
-import osmnx as ox
-
-# Matplotlib-related stuff, for drawing
-from matplotlib.path import Path
-from matplotlib import pyplot as plt
-from matplotlib.patches import PathPatch
-
-# CV2 & Scipy & Numpy & Pandas
-import numpy as np
-from numpy.random import choice
-
-# Shapely
-from shapely.geometry import *
-from shapely.affinity import *
-
-# Geopandas
-from geopandas import GeoDataFrame
-
-# etc
 import re
-import pandas as pd
-from functools import reduce
-from tabulate import tabulate
-from IPython.display import Markdown, display
 from collections.abc import Iterable
 
-# Fetch
-from .fetch import *
+import osmnx as ox
+import pandas as pd
+import numpy as np
+from numpy.random import choice
+from shapely.geometry import Polygon, MultiPolygon, MultiLineString, GeometryCollection
+from shapely.affinity import translate, scale, rotate
+from descartes import PolygonPatch
+from tabulate import tabulate
+from IPython.display import Markdown, display
+
+from .fetch import get_perimeter, get_layer
+
 
 # Helper functions
 def get_hash(key):

--- a/prettymaps/fetch.py
+++ b/prettymaps/fetch.py
@@ -1,28 +1,11 @@
-# OpenStreetMap Networkx library to download data from OpenStretMap
-from ast import Mult
-from operator import ge
+from functools import reduce
+
 import osmnx as ox
-
-# CV2 & Scipy & Numpy & Pandas
 import numpy as np
-
-# Shapely
-from shapely.geometry import *
-from shapely.affinity import *
+from shapely.geometry import Point, Polygon, MultiPolygon, MultiLineString
 from shapely.ops import unary_union
-
-# Geopandas
 from geopandas import GeoDataFrame
 
-# Matplotlib
-from matplotlib.path import Path
-
-# etc
-from collections.abc import Iterable
-from functools import reduce
-from descartes import PolygonPatch
-
-from functools import reduce
 
 # Compute circular or square boundary given point, radius and crs
 def get_boundary(point, radius, crs, circle = True, dilate = 0):


### PR DESCRIPTION
Best practice structure for imports & cleanup:
- New structure: Standard library, Third party, modules
- Explicit imports instead of import full modules
- Cleaned up