### PR TITLE
Add retain_all option to get_streets()

### DIFF
--- a/prettymaps/fetch.py
+++ b/prettymaps/fetch.py
@@ -80,7 +80,7 @@ def get_geometries(perimeter = None, point = None, radius = None, tags = {}, per
     return geometries
 
 # Get streets
-def get_streets(perimeter = None, point = None, radius = None, layer = 'streets', width = 6, custom_filter = None, buffer = 0,circle = True, dilate = 0):
+def get_streets(perimeter = None, point = None, radius = None, layer = 'streets', width = 6, custom_filter = None, buffer = 0, retain_all = False, circle = True, dilate = 0):
 
     if layer == 'streets':
         layer = 'highway'
@@ -94,7 +94,7 @@ def get_streets(perimeter = None, point = None, radius = None, layer = 'streets'
     # Boundary defined by polygon (perimeter)
     elif (point is not None) and (radius is not None):
         # Fetch streets data, save CRS & project
-        streets = ox.graph_from_point(point, dist = radius+dilate+buffer, custom_filter = custom_filter)
+        streets = ox.graph_from_point(point, dist = radius+dilate+buffer, retain_all = retain_all, custom_filter = custom_filter)
         crs = ox.graph_to_gdfs(streets, nodes = False).crs
         streets = ox.project_graph(streets)
         # Compute perimeter from point & CRS


### PR DESCRIPTION
So I could get rail lines to show up on the map I used a layer with a custom filter. At first I excluded the `["tunnel"!="yes"]` and I was getting trainlines that were underground showing up, so I added this filter so I could only keep the trainlines above ground.

```
'railway':{
            'custom_filter': '["railway"~"rail"]["tunnel"!="yes"]',
            'width':2,
            'circle':False,
            'buffer':3000,
            'retain_all':True
},
```

When I did this almost all the trainlines seemed to dissappear, so I made them show up bright red. This showed that only the centre of the map (at the train station) had trainlines, as seen below:

**_retain_all = False_**
![image](https://user-images.githubusercontent.com/55803987/131249996-40e789f8-dee0-4285-82aa-47d66c403e00.png)

This is because `ox.graph_from_point` has `retain_all` set to False by default, so it only keeps the largest graph. When the `["tunnel"!="yes"]` filter is used, it splits the graphs up, so it only keeps the largest bit.

I added a retain_all option to `get_streets()` so that separate graphs can be kept instead of only keeping the largest. Setting `retain_all` to `True` I get the result below, where all of the trainlines that match the filter are visible. In this case, the trainlines can be seen going west of the train station and going through a tunnel under a building before reappearing in a park and dissappearing underground again towards the edge of the map.

**_retain_all = True_**
![image](https://user-images.githubusercontent.com/55803987/131250199-b794de5d-b5ef-4fbb-866c-81aeff964459.png)
