### PR TITLE
fix issue when querying within a polygon

### DIFF
--- a/prettymaps/draw.py
+++ b/prettymaps/draw.py
@@ -106,7 +106,7 @@ def plot_shapes(shapes, ax, vsketch = None, palette = None, **kwargs):
 
 # Parse query (by coordinates, OSMId or name)
 def parse_query(query):
-    if isinstance(query, (Polygon, MultiPolygon)):
+    if isinstance(query, GeoDataFrame):
         return 'polygon'
     elif isinstance(query, tuple):
         return 'coordinates'


### PR DESCRIPTION
The `parse_query` function checked whether the `query` parameter was of type `Polygon` or `MultiPolygon`, while the underlying library expected a `GeoDataFrame` (which is also what `get_perimeter` returns).

This should also be useful for #31.