### PR TITLE
Fix geometry-perimeter intersection

### DIFF
--- a/prettymaps/fetch.py
+++ b/prettymaps/fetch.py
@@ -47,7 +47,7 @@ def get_geometries(perimeter = None, point = None, radius = None, tags = {}, per
         geometries = ox.project_gdf(geometries)
 
     # Intersect with perimeter
-    geometries = geometries.intersection(perimeter)
+    geometries = geometries.intersection(perimeter).buffer(0)
 
     if union:
         geometries = unary_union(reduce(lambda x,y: x+y, [

--- a/prettymaps/fetch.py
+++ b/prettymaps/fetch.py
@@ -94,10 +94,10 @@ def get_streets(perimeter = None, point = None, radius = None, layer = 'streets'
         streets = unary_union([
             # Dilate streets of each highway type == 'highway' using width 'w'
             MultiLineString(
-                streets[(streets[layer] == highway) & (streets.geometry.type == 'LineString')].geometry.tolist() +
+                streets[ [highway in value for value in streets[layer]] & (streets.geometry.type == 'LineString')].geometry.tolist() +
                 list(reduce(lambda x, y: x+y, [
                     list(lines)
-                    for lines in streets[(streets[layer] == highway) & (streets.geometry.type == 'MultiLineString')].geometry
+                    for lines in streets[ [highway in value for value in streets[layer]] & (streets.geometry.type == 'MultiLineString')].geometry
                 ], []))
             ).buffer(w)
             for highway, w in width.items()


### PR DESCRIPTION
Some geometry was removed, even through it was partially in the perimeter such as in issue #46 where not all the river was visible because the last bit partially went out of the perimeter. This seemed to happen when a perimeter was provided and not a point or radius.

If `geometries = geometries.intersection(perimeter)` is changed to `geometries = geometries.intersection(perimeter).buffer(0)` it seems to have behaviour that would be expected.

__*Before change*__
![image](https://user-images.githubusercontent.com/55803987/131852790-446a7f5c-0752-4a72-a190-d27f18698a81.png)

__*After change*__
![image](https://user-images.githubusercontent.com/55803987/131852562-f1b531ba-abd8-41e0-8767-21f8b7cd1cbd.png)

Also the buffer on the perimeter in `get_geometries()` and `get_streets()` was being performed on the longitude and latitude in degrees, not meters. It now projects it, buffers it in meters, then turns it back into degrees for the `ox.geometries_from_polygon()`/`ox.graph_from_polygon()`.

The `get_streets()` function would have streets going over the perimeter when only used with a `perimeter`. This was because the intersection code wasn't running when only a `perimeter` was used, and the `perimeter` was still a `GeoDataFrame` because the line `perimeter = unary_union(ox.project_gdf(perimeter).geometry)` was missing.
