### PR TITLE
Remove Jupyter as a depedency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 osmnx==1.0.1
 tabulate==0.8.9
-jupyter==1.0.0
 #vsketch==1.0.0


### PR DESCRIPTION
I see no reason to have Jupyter as a dependency. I've installed prettymaps on my local machine, and don't want to have the overhead of installing Jupyter.