### PR TITLE
Fix "Multi-part geometries do not themselves provide the array interface" when using non dict width

### DIFF
--- a/prettymaps/fetch.py
+++ b/prettymaps/fetch.py
@@ -221,7 +221,19 @@ def get_streets(
         )
     else:
         # Dilate all streets by same amount 'width'
-        streets = MultiLineString(streets.geometry.tolist()).buffer(width)
+        streets=  MultiLineString(
+            streets[streets.geometry.type == "LineString"].geometry.tolist()
+            + list(
+                reduce(
+                    lambda x, y: x + y,
+                    [
+                        list(lines)
+                        for lines in streets[streets.geometry.type == "MultiLineString"].geometry
+                    ],
+                    [],
+                )
+            )
+        ).buffer(width)
 
     return streets
 


### PR DESCRIPTION
Issue: When using a non dict width for streets, waterways and railways, such as ```'streets': {'width': 2}```, code errors out with:

```
Traceback (most recent call last):
  File "c:\Users\GuildTV\Desktop\pretty maps\index.py", line 12, in <module>
    backup = plot(
  File "C:\Users\GuildTV\AppData\Local\Programs\Python\Python39\lib\site-packages\prettymaps\draw.py", line 191, in plot
    layers = {
  File "C:\Users\GuildTV\AppData\Local\Programs\Python\Python39\lib\site-packages\prettymaps\draw.py", line 192, in <dictcomp>
    layer: get_layer(
  File "C:\Users\GuildTV\AppData\Local\Programs\Python\Python39\lib\site-packages\prettymaps\fetch.py", line 250, in get_layer
    return get_streets(**kwargs, layer=layer)
  File "C:\Users\GuildTV\AppData\Local\Programs\Python\Python39\lib\site-packages\prettymaps\fetch.py", line 224, in get_streets
    streets = MultiLineString(streets.geometry.tolist()).buffer(width)
  File "C:\Users\GuildTV\AppData\Local\Programs\Python\Python39\lib\site-packages\shapely\geometry\multilinestring.py", line 53, in __init__
    self._geom, self._ndim = geos_multilinestring_from_py(lines)
  File "C:\Users\GuildTV\AppData\Local\Programs\Python\Python39\lib\site-packages\shapely\geometry\multilinestring.py", line 135, in geos_multilinestring_from_py
    geom, ndims = linestring.geos_linestring_from_py(obs[l])
  File "shapely\speedups\_speedups.pyx", line 88, in shapely.speedups._speedups.geos_linestring_from_py
  File "C:\Users\GuildTV\AppData\Local\Programs\Python\Python39\lib\site-packages\shapely\geometry\base.py", line 854, in __array_interface__
    raise NotImplementedError("Multi-part geometries do not themselves "
NotImplementedError: Multi-part geometries do not themselves provide the array interface
```
 Fix: handle MultiLineStrings the same way they are handled when a width dict is used, through reducing. 