### PR TITLE
build: Add MANIFEST.in with prune strategy

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,11 @@
+prune **
+graft prettymaps
+
+include setup.py
+include LICENSE
+include README.md
+include MANIFEST.in
+
+include requirements.txt
+
+global-exclude __pycache__ *.py[cod]


### PR DESCRIPTION
* Resolves #65
* Needed for Issue #67

```
* Use `prune **` to remove all files from the sdist
    - c.f. https://packaging.python.org/guides/using-manifest-in/#manifest-in-commands
    - "Setuptools also has undocumented support for ** matching zero or
       more characters including forward slash, backslash, and colon."
* Manually include all "default" files for a sdist in MANIFEST.in
    - c.f. https://packaging.python.org/guides/using-manifest-in/#how-files-are-included-in-an-sdist
* Include requirements.txt as not using declartive spec for setup
```