### PR TITLE
ci: Add publishing workflow with GitHub Actions

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,64 @@
+name: publish distributions
+
+on:
+  push:
+    branches:
+    - main
+    tags:
+      - v*
+  pull_request:
+    branches:
+    - main
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build-and-publish:
+    name: Build and publish Python distro to (Test)PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Install build and twine
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install build twine
+        python -m pip list
+
+    - name: Build a sdist and a wheel
+      run: python -m build --outdir dist/ .
+
+    - name: Verify the distribution
+      run: twine check dist/*
+
+    - name: List contents of sdist
+      run: python -m tarfile --list dist/prettymaps-*.tar.gz
+
+    - name: List contents of wheel
+      run: python -m zipfile --list dist/prettymaps-*.whl
+
+    - name: Publish distribution 📦 to Test PyPI
+      # publish to TestPyPI on tag events
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'marceloprates/prettymaps'
+      uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+
+    - name: Publish distribution 📦 to PyPI
+      # publish to PyPI on releases
+      if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'marceloprates/prettymaps'
+      uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Resolves #67

Add GHA based workflow to release a sdist and wheel to:
- TestPyPI on tags
- PyPI on GitHub releases

---

Things that @marceloprates would need to do for this PR to work:

- Get [API tokens for TestPyPI and PyPI](https://pypi.org/help/#apitoken)
- Save them respectively as GitHub secrets for this repo named `test_pypi_password` and `pypi_password`

---

Example resulting release workflow:

Locally on `main` run:

```console
$ git checkout main && git pull # verify that you're on main and synced with GitHub
$ <whatever you need to do to bump the release number>  # Matthew uses bump2version on most of his projects, but whatever works here
$ git push origin main --tags # push the commit and the tag to GitHub, causing TestPyPI to publish
```

- Got to TestPyPI (https://test.pypi.org/project/prettymaps/) to look if the release looks okay
- Then on GitHub:
   1. Go to releases: https://github.com/marceloprates/prettymaps/releases
   2. Click "Draft a new release"
   3. On the new page enter the tag you just pushed (e.g. `v0.1.0`) in the "Tag version" box and the "Release title" box (to make it easy unless you really want to get descriptive)
   4. Enter any release notes and click "Publish release"
- This then kicks of the publication CD workflow that will use the PyPI API key to publish.