### PR TITLE
Added `Shapely` to the requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 osmnx==1.0.1
 tabulate==0.8.9
+Shapely<=1.7.1
 #vsketch==1.0.0


### PR DESCRIPTION
There is no restriction on which version of `Shapely` will be installed (it is the latest, as per `pip` default).  The deprecation warning that is thrown is (see the `Shapely` documentation on the [migration](https://shapely.readthedocs.io/en/stable/migration.html)) 

```
ShapelyDeprecationWarning: Setting the 'coords' to mutate a Geometry
in place is deprecated, and will not be possible any more in Shapely 2.0
```

This is a placeholder as the underlying code has to be refactored to accommodate the changes.