### PR TITLE
add support for rectanular radius

### DIFF
--- a/prettymaps/fetch.py
+++ b/prettymaps/fetch.py
@@ -60,15 +60,19 @@ def get_boundary(query, radius, circle=False, rotation=0):
     if circle:  # Circular shape
         # use .buffer() to expand point into circle
         boundary.geometry = boundary.geometry.buffer(radius)
-    else:  # Square shape
+    else:  # Rectangular shape
         x, y = np.concatenate(boundary.geometry[0].xy)
-        r = radius
+        if type(radius) is tuple:
+            x_radius = radius[0]
+            y_radius = radius[1]
+        else:
+            x_radius = y_radius = radius
         boundary = GeoDataFrame(
             geometry=[
                 rotate(
                     Polygon(
-                        [(x - r, y - r), (x + r, y - r),
-                         (x + r, y + r), (x - r, y + r)]
+                        [(x - x_radius, y - y_radius), (x + x_radius, y - y_radius),
+                         (x + x_radius, y + y_radius), (x - x_radius, y + y_radius)]
                     ),
                     rotation,
                 )


### PR DESCRIPTION
Currently it is not easily possible to create a rectangular shape from coordinates.
This PR simply extends the `get_boundary` function to also accept a tuple for the radius (to define "x-radius" and "y-radius").
This is a bit of a hacky solution, but I hacked it into my fork for a small project, and I thought it might make sense to file a PR.
Feel free to drop / close this PR if it's too hacky ;)

Here's a test-snippet for the barcelona example from the README:
```
from prettymaps import *
from matplotlib import pyplot as plt

plot(
    (41.39491,2.17557),
    radius=(500, 707),
    figsize=(8.27, 11.69),
    preset="barcelona",
    save_as=f'barcelona.svg'
)
```

This would result in the following image:
![barcelona](https://github.com/marceloprates/prettymaps/assets/2796604/acaa2922-ffad-409f-97a6-135c89d9ddeb)

Fixes https://github.com/marceloprates/prettymaps/issues/81

PS.: Thanks for this awesome OSS project! 😍 