### PR TITLE
Use `retain_all` when fetching graph

### DIFF
--- a/prettymaps/fetch.py
+++ b/prettymaps/fetch.py
@@ -157,6 +157,7 @@ def get_gdf(
         if layer in ["streets", "railway", "waterway"]:
             graph = ox.graph_from_polygon(
                 bbox,
+                retain_all=True,
                 custom_filter=custom_filter,
                 truncate_by_edge=True,
             )


### PR DESCRIPTION
```    
retain_all : bool
        if True, return the entire graph even if it is not connected.
        otherwise, retain only the largest weakly connected component.
```

If the streets aren't all connected, some streets are not fetched. Turning `retain_all` on ensures all streets in the area are drawn.