### PR TITLE
Fix osmnx dependency to version 1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.20,<1.25
 matplotlib>=3.9.0
 shapely>=2.0.0
-osmnx>=1.9.3
+osmnx>=1.9.3,<2.0
 ipykernel>=6.29.5


### PR DESCRIPTION
Without this it will try to install osmnx version 2, which had breaking changes and causes prettymaps to fail with the error
```
AttributeError: module 'osmnx' has no attribute 'project_gdf'. Did you mean: 'project_graph'?
```