### PR TITLE
Add GPX/KML track support (#64): frame a map around a track and draw it as a layer

### DIFF
--- a/prettymaps/draw.py
+++ b/prettymaps/draw.py
@@ -56,7 +56,11 @@ import shutil
 
 # Local imports
 from .fetch import get_gdfs, obtain_elevation, get_keypoints
+from .gpx import read_track, is_track_file, track_center, track_radius
 from .utils import log_execution_time
+
+# Default matplotlib style for a GPX/KML track layer (see the `gpx` arg of plot()).
+GPX_STYLE = {"ec": "#EB4034", "lw": 3, "zorder": 6}
 
 # Log configuration for elapsed time
 logging.basicConfig(
@@ -1130,6 +1134,8 @@ def plot(
     logging: bool = False,
     semantic: bool = False,
     adjust_aspect_ratio: bool = True,
+    gpx: str | List[str] | None = None,
+    gpx_style: Dict[str, Any] | None = None,
 ) -> Plot:
     """
     Plots a map based on a given query and specified parameters.
@@ -1161,9 +1167,23 @@ def plot(
         scale_y: Scaling parameter in the y direction. Defaults to 1.
         rotation: Rotation parameter in degrees. Defaults to 0.
         logging: Whether to enable logging. Defaults to False.
+        gpx: Path (or list of paths) to a GPX/KML file whose track is drawn on the map as a "gpx" layer. If `query` is itself a GPX/KML file, the map is framed around that track and it is drawn automatically. Defaults to None.
+        gpx_style: Matplotlib style for the GPX track layer (e.g. {"ec": "#EB4034", "lw": 3}). Overrides `GPX_STYLE`; ignored if `style["gpx"]` is given. Defaults to None.
     Returns:
         Plot: The resulting plot object.
     """
+
+    # 0. Read a GPX/KML track, if given, to frame the map around it and/or draw it
+    track_geom = None
+    gpx_source = gpx if gpx is not None else (query if is_track_file(query) else None)
+    if gpx_source is not None:
+        track_geom = read_track(gpx_source)
+    if track_geom is not None and is_track_file(query):
+        # The query IS the track file: centre the map on the track and, unless the
+        # caller fixed a radius, choose one that encloses the whole track.
+        if radius is None:
+            radius = track_radius(track_geom)
+        query = track_center(track_geom)
 
     # 1. Manage presets
     layers, style, circle, radius, dilate = manage_presets(
@@ -1196,6 +1216,13 @@ def plot(
     gdfs = get_gdfs(query, layers, radius, dilate, -rotation, logging=logging)
     fetch_time = time.time() - start_time
     print(f"Fetching geodataframes took {fetch_time:.2f} seconds")
+
+    # 4b. Inject the GPX/KML track as a "gpx" layer (rides through the same
+    # projection, transforms and drawing as every other layer).
+    if track_geom is not None:
+        gdfs["gpx"] = gp.GeoDataFrame(geometry=[track_geom], crs="EPSG:4326")
+        layers.setdefault("gpx", {})
+        style.setdefault("gpx", {**GPX_STYLE, **(gpx_style or {})})
 
     # 5. Apply transformations to GeoDataFrames (translation, scale, rotation)
     gdfs = transform_gdfs(gdfs, x, y, scale_x, scale_y, rotation, logging=logging)

--- a/prettymaps/draw.py
+++ b/prettymaps/draw.py
@@ -396,7 +396,7 @@ def plot_gdf(
                         **{
                             k: v
                             for k, v in kwargs.items()
-                            if k in ["lw", "lt", "dashes", "zorder"]
+                            if k in ["lw", "ls", "dashes", "zorder"]
                         },
                     )
         elif mode == "plotter":

--- a/prettymaps/gpx.py
+++ b/prettymaps/gpx.py
@@ -1,0 +1,131 @@
+"""
+Read GPS tracks (GPX / KML) into shapely geometries.
+
+Used by :func:`prettymaps.draw.plot` to (a) frame a map around a recorded track
+and (b) draw the track as a map layer. See GitHub issue #64.
+
+The parser is intentionally dependency-free (standard-library XML only) and
+namespace-agnostic, so it accepts GPX 1.0/1.1 and KML files regardless of the
+declared XML namespace.
+"""
+
+import math
+import xml.etree.ElementTree as ET
+from typing import List, Optional, Tuple, Union
+
+from shapely.geometry import LineString, MultiLineString
+from shapely.geometry.base import BaseGeometry
+
+# Mean metres-per-degree of latitude (WGS84). Longitude is scaled by cos(lat).
+_M_PER_DEG = 111_320.0
+
+__all__ = ["read_track", "is_track_file", "track_center", "track_radius"]
+
+
+def _localname(tag: str) -> str:
+    """Return an element's tag without its XML namespace, lower-cased."""
+    return tag.rsplit("}", 1)[-1].lower()
+
+
+def _lines_from_gpx(root: ET.Element) -> List[LineString]:
+    """Extract track segments (trk/trkseg) and routes (rte) as LineStrings."""
+    lines = []
+    for element in root.iter():
+        if _localname(element.tag) in ("trkseg", "rte"):
+            points = []
+            for point in element:
+                if _localname(point.tag) in ("trkpt", "rtept"):
+                    try:
+                        points.append((float(point.get("lon")), float(point.get("lat"))))
+                    except (TypeError, ValueError):
+                        continue
+            if len(points) >= 2:
+                lines.append(LineString(points))
+    return lines
+
+
+def _lines_from_kml(root: ET.Element) -> List[LineString]:
+    """Extract <LineString><coordinates> paths ("lon,lat,alt lon,lat,alt ...")."""
+    lines = []
+    for element in root.iter():
+        if _localname(element.tag) != "linestring":
+            continue
+        for child in element:
+            if _localname(child.tag) != "coordinates":
+                continue
+            points = []
+            for token in (child.text or "").split():
+                parts = token.split(",")
+                if len(parts) >= 2:
+                    try:
+                        points.append((float(parts[0]), float(parts[1])))
+                    except ValueError:
+                        continue
+            if len(points) >= 2:
+                lines.append(LineString(points))
+    return lines
+
+
+def read_track(
+    source: Union[str, List[str], Tuple[str, ...]]
+) -> Optional[MultiLineString]:
+    """
+    Read one or more GPX/KML files into a single shapely ``MultiLineString``.
+
+    Coordinates are longitude/latitude (EPSG:4326), matching osmnx/prettymaps.
+
+    Args:
+        source: A path to a ``.gpx`` or ``.kml`` file, or a list of such paths.
+
+    Returns:
+        A ``MultiLineString`` of every track segment / route / line found, or
+        ``None`` if the file(s) contain no usable line geometry.
+    """
+    if isinstance(source, (list, tuple)):
+        geoms: List[LineString] = []
+        for item in source:
+            track = read_track(item)
+            if track is not None:
+                geoms.extend(track.geoms)
+        return MultiLineString(geoms) if geoms else None
+
+    root = ET.parse(source).getroot()
+    root_name = _localname(root.tag)
+    if root_name == "kml":
+        lines = _lines_from_kml(root)
+    elif root_name == "gpx":
+        lines = _lines_from_gpx(root)
+    else:
+        # Unknown root: try both readers.
+        lines = _lines_from_gpx(root) or _lines_from_kml(root)
+
+    return MultiLineString(lines) if lines else None
+
+
+def is_track_file(query: object) -> bool:
+    """True if ``query`` is a path to a ``.gpx`` or ``.kml`` file."""
+    return isinstance(query, str) and query.lower().rsplit(".", 1)[-1] in ("gpx", "kml")
+
+
+def track_center(geom: BaseGeometry) -> Tuple[float, float]:
+    """Return the ``(latitude, longitude)`` centre of a track's bounding box."""
+    min_lon, min_lat, max_lon, max_lat = geom.bounds
+    return (min_lat + max_lat) / 2, (min_lon + max_lon) / 2
+
+
+def track_radius(
+    geom: BaseGeometry, margin: float = 1.15, min_radius: float = 250.0
+) -> float:
+    """
+    A square "radius" (half-side, in metres) that encloses the whole track.
+
+    Args:
+        geom: Track geometry in lon/lat (EPSG:4326).
+        margin: Multiplier applied so the track doesn't touch the map edge.
+        min_radius: Floor for very short tracks, so the map isn't absurdly zoomed.
+    """
+    min_lon, min_lat, max_lon, max_lat = geom.bounds
+    center_lat = (min_lat + max_lat) / 2
+    width_m = (max_lon - min_lon) * _M_PER_DEG * math.cos(math.radians(center_lat))
+    height_m = (max_lat - min_lat) * _M_PER_DEG
+    return max(min_radius, (max(width_m, height_m) / 2) * margin)

--- a/tests/test_gpx.py
+++ b/tests/test_gpx.py
@@ -1,0 +1,151 @@
+"""Tests for GPX / KML track support (issue #64)."""
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import LineString, MultiLineString, Polygon
+
+import prettymaps
+import prettymaps.draw as draw
+from prettymaps.gpx import is_track_file, read_track, track_center, track_radius
+
+_GPX_SAMPLE = """<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+  <trk><name>seg1</name><trkseg>
+    <trkpt lat="41.8800" lon="-87.6300"/>
+    <trkpt lat="41.8810" lon="-87.6320"/>
+    <trkpt lat="41.8820" lon="-87.6340"/>
+  </trkseg></trk>
+  <trk><trkseg>
+    <trkpt lat="41.8790" lon="-87.6280"/>
+    <trkpt lat="41.8795" lon="-87.6290"/>
+  </trkseg></trk>
+</gpx>
+"""
+
+_KML_SAMPLE = """<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2"><Document><Placemark><LineString>
+  <coordinates>-87.6300,41.8800,0 -87.6320,41.8810,0 -87.6340,41.8820,0</coordinates>
+</LineString></Placemark></Document></kml>
+"""
+
+
+# --- parser -----------------------------------------------------------------
+
+def test_is_track_file():
+    assert is_track_file("walk.gpx")
+    assert is_track_file("WALK.GPX")
+    assert is_track_file("route.kml")
+    assert not is_track_file("Porto Alegre")
+    assert not is_track_file((41.39, 2.17))
+
+
+def test_read_track_gpx(tmp_path):
+    path = tmp_path / "walk.gpx"
+    path.write_text(_GPX_SAMPLE)
+    geom = read_track(str(path))
+    assert isinstance(geom, MultiLineString)
+    assert len(geom.geoms) == 2
+    lat, lon = track_center(geom)
+    assert 41.87 < lat < 41.89 and -87.64 < lon < -87.62
+    assert track_radius(geom) >= 250.0
+
+
+def test_read_track_kml(tmp_path):
+    path = tmp_path / "walk.kml"
+    path.write_text(_KML_SAMPLE)
+    geom = read_track(str(path))
+    assert isinstance(geom, MultiLineString)
+    assert len(geom.geoms) == 1
+
+
+def test_read_track_missing_geometry(tmp_path):
+    path = tmp_path / "empty.gpx"
+    path.write_text('<?xml version="1.0"?><gpx xmlns="http://www.topografix.com/GPX/1/1"/>')
+    assert read_track(str(path)) is None
+
+
+def test_read_track_multiple_files(tmp_path):
+    a = tmp_path / "a.gpx"; a.write_text(_GPX_SAMPLE)
+    b = tmp_path / "b.kml"; b.write_text(_KML_SAMPLE)
+    geom = read_track([str(a), str(b)])
+    assert isinstance(geom, MultiLineString)
+    assert len(geom.geoms) == 3
+
+
+# --- plot() integration (draw functions mocked; no network) -----------------
+
+def _mock_draw(monkeypatch):
+    monkeypatch.setattr(draw, "transform_gdfs", lambda gdfs, *a, **k: gdfs)
+    monkeypatch.setattr(draw, "create_background", lambda *a, **k: (None, 0, 0, 0, 0, 0, 0))
+    monkeypatch.setattr(draw, "draw_layers", lambda *a, **k: None)
+    monkeypatch.setattr(draw, "draw_keypoints", lambda *a, **k: None)
+    monkeypatch.setattr(draw, "draw_background", lambda *a, **k: None)
+    monkeypatch.setattr(draw, "draw_credit", lambda *a, **k: None)
+    monkeypatch.setattr(draw, "draw_hillshade", lambda *a, **k: None)
+
+
+def _square(min_lon, min_lat, max_lon, max_lat):
+    return gpd.GeoDataFrame(
+        geometry=[Polygon([(min_lon, min_lat), (max_lon, min_lat),
+                           (max_lon, max_lat), (min_lon, max_lat)])],
+        crs="EPSG:4326",
+    )
+
+
+def test_plot_gpx_query_autoframes_and_draws(monkeypatch, tmp_path):
+    """A GPX file as the query frames the map around it and adds a 'gpx' layer."""
+    path = tmp_path / "walk.gpx"; path.write_text(_GPX_SAMPLE)
+    perim = _square(-87.64, 41.87, -87.62, 41.89)
+    captured = {}
+
+    def fake_get_gdfs(query, *a, **k):
+        captured["query"] = query
+        return {"perimeter": perim.copy()}
+
+    monkeypatch.setattr(draw, "get_gdfs", fake_get_gdfs)
+    _mock_draw(monkeypatch)
+    result = prettymaps.plot(str(path), show=False)
+    # query was replaced by the track centre (a lat/lon tuple)
+    assert isinstance(captured["query"], tuple)
+    # the track was injected as a drawable line layer
+    assert "gpx" in result.geodataframes
+    geom = result.geodataframes["gpx"].geometry.iloc[0]
+    assert isinstance(geom, (LineString, MultiLineString))
+
+
+def test_plot_gpx_param_overlays_without_reframing(monkeypatch, tmp_path):
+    """`gpx=` draws the track over a normal query without changing that query."""
+    path = tmp_path / "walk.gpx"; path.write_text(_GPX_SAMPLE)
+    perim = _square(0, 0, 1, 1)
+    captured = {}
+
+    def fake_get_gdfs(query, *a, **k):
+        captured["query"] = query
+        return {"perimeter": perim.copy()}
+
+    monkeypatch.setattr(draw, "get_gdfs", fake_get_gdfs)
+    _mock_draw(monkeypatch)
+    result = prettymaps.plot("Porto Alegre", gpx=str(path), show=False)
+    assert captured["query"] == "Porto Alegre"  # not reframed
+    assert "gpx" in result.geodataframes
+
+
+def test_plot_gpx_custom_style(monkeypatch, tmp_path):
+    """gpx_style overrides the default track style passed to draw_layers."""
+    path = tmp_path / "walk.gpx"; path.write_text(_GPX_SAMPLE)
+    perim = _square(0, 0, 1, 1)
+    style_seen = {}
+
+    monkeypatch.setattr(draw, "get_gdfs", lambda *a, **k: {"perimeter": perim.copy()})
+    monkeypatch.setattr(draw, "transform_gdfs", lambda gdfs, *a, **k: gdfs)
+    monkeypatch.setattr(draw, "create_background", lambda *a, **k: (None, 0, 0, 0, 0, 0, 0))
+    monkeypatch.setattr(draw, "draw_layers",
+                        lambda layers, gdfs, style, *a, **k: style_seen.update(style))
+    monkeypatch.setattr(draw, "draw_keypoints", lambda *a, **k: None)
+    monkeypatch.setattr(draw, "draw_background", lambda *a, **k: None)
+    monkeypatch.setattr(draw, "draw_credit", lambda *a, **k: None)
+    monkeypatch.setattr(draw, "draw_hillshade", lambda *a, **k: None)
+    prettymaps.plot("Porto Alegre", gpx=str(path),
+                    gpx_style={"ec": "#123456", "lw": 9}, show=False)
+    assert style_seen["gpx"]["ec"] == "#123456"
+    assert style_seen["gpx"]["lw"] == 9


### PR DESCRIPTION
Rebased onto `develop` from #143 (the original PR was base=`main` and we now use `develop` for new work).

This is the same single commit from postmaxin's #143 — `54ea632` — by Tyler MacDonald.
All credit stays with the original author.

Closes #64.

Adds GPX/KML track support:

- `plot("track.gpx")` frames the map on the track (auto-picks a radius, unless one is given) and draws it.
- `plot(query, gpx="track.gpx")` draws the track over a normal query.
- `gpx` accepts a path or a list of paths; GPX and KML are both read.
- `gpx_style` (or `style["gpx"]`) styles the track layer; defaults to `GPX_STYLE`.

The track is injected as a `"gpx"` layer, so it flows through the same projection, transform and drawing pipeline as every other layer (plot_gdf already renders LineString/MultiLineString). The reader (prettymaps/gpx.py) uses only the standard library + shapely — **no new dependencies**.

`tests/test_gpx.py` covers the reader (GPX, KML, multi-file, empty) and the `plot()` integration (auto-frame, overlay, custom style). 9/9 tests pass.

Supersedes the stale #80 (pre-1.0 architecture).