### PR TITLE
Log swallowed OSM fetch errors and guard missing 'highway' column

### DIFF
--- a/prettymaps/draw.py
+++ b/prettymaps/draw.py
@@ -197,9 +197,14 @@ def graph_to_shapely(gdf: gp.GeoDataFrame, width: float = 1.0) -> BaseGeometry:
             return np.nan
 
     # Annotate GeoDataFrame with the width for each highway type
-    gdf["width"] = (
-        gdf["highway"].map(highway_to_width) if type(width) == dict else width
-    )
+    if type(width) == dict:
+        if "highway" in gdf.columns:
+            gdf["width"] = gdf["highway"].map(highway_to_width)
+        else:
+            # 'highway' column missing (e.g. street fetch returned no data) - treat as no known width
+            gdf["width"] = np.nan
+    else:
+        gdf["width"] = width
 
     # Remove rows with inexistent width
     gdf.drop(gdf[gdf.width.isna()].index, inplace=True)

--- a/prettymaps/fetch.py
+++ b/prettymaps/fetch.py
@@ -607,6 +607,7 @@ def unified_osm_request(
     try:
         all_features = ox.features.features_from_polygon(bbox, tags=combined_tags)
     except Exception as e:
+        logging.warning(f"Failed to fetch features for combined tags: {e}")
         all_features = GeoDataFrame(geometry=[])
 
     # Split the features into separate GeoDataFrames based on the layers_dict
@@ -690,7 +691,7 @@ def unified_osm_request(
             gdfs[layer] = gdf
             # write_to_cache(perimeter, gdf, layers_dict[layer])
         except Exception as e:
-            # print(f"Error fetching {layer}: {e}")
+            logging.warning(f"Error fetching layer '{layer}': {e}")
             gdfs[layer] = GeoDataFrame(geometry=[])
 
     return gdfs


### PR DESCRIPTION
Fixes #159, Fixes #154

`fetch.py` had two bare `except Exception:` blocks that silently discarded every error during Overpass/OSM fetches (rate limits, timeouts, malformed responses), returning an empty `GeoDataFrame` with no trace of what failed. One of them even had its diagnostic `print` commented out.

This made failures undebuggable, and could cascade into a `KeyError: 'highway'` crash in `draw.py`'s `graph_to_shapely` when a failed street-layer fetch left the GeoDataFrame without a `highway` column.

**Changes:**
- `fetch.py`: log the exception via `logging.warning` instead of discarding it silently (both call sites)
- `draw.py`: fall back to `NaN` width when `highway` is missing instead of crashing, so the layer is just dropped (same as the existing "no known width" path)

Tested: full `pytest` suite passes (9/9), plus manual smoke-test renders across several locations.