### PR TITLE
fix: crashes and dead cache in OSM layer fetch

### DIFF
--- a/docs/superpowers/plans/2026-08-23-cli-and-skill.md
+++ b/docs/superpowers/plans/2026-08-23-cli-and-skill.md
@@ -1,0 +1,323 @@
+# prettymaps CLI + Global Claude Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a minimal `prettymaps` CLI (`plot`, `list-presets`) installable via `pip install -e .`, and a global Claude Code skill that drives it from any project.
+
+**Architecture:** `prettymaps/cli.py` wraps the existing `plot()`/`presets()` functions with `argparse`. `setup.py` registers a `prettymaps` console script pointing at `cli.main`. A dedicated `.venv` in the repo hosts the editable install. A skill file at `~/.claude/skills/prettymaps/SKILL.md` tells Claude to invoke the venv's `prettymaps` executable by absolute path from any project.
+
+**Tech Stack:** Python 3.12, `argparse` (stdlib), existing `prettymaps` package, `pytest` for tests.
+
+Spec: [`docs/superpowers/specs/2026-08-23-cli-and-skill-design.md`](../specs/2026-08-23-cli-and-skill-design.md)
+
+---
+
+### Task 1: Create the venv
+
+**Files:** none (shell only)
+
+- [ ] **Step 1: Create the venv**
+
+Run: `python -m venv .venv`
+Expected: creates `.venv/` in the repo root (already covered by `.gitignore`; verify with `git status` that nothing new is tracked).
+
+- [ ] **Step 2: Install the package in editable mode**
+
+Run (Windows Git Bash): `.venv/Scripts/python.exe -m pip install -e .`
+Expected: installs `prettymaps` plus everything in `requirements.txt`. This takes a few minutes (rasterio/opencv/osmnx are large). No errors at the end.
+
+- [ ] **Step 3: Install pytest into the venv**
+
+Run: `.venv/Scripts/python.exe -m pip install pytest`
+Expected: pytest installed, no errors.
+
+---
+
+### Task 2: CLI `plot` command
+
+**Files:**
+- Create: `prettymaps/cli.py`
+- Test: `tests/test_cli.py`
+
+- [ ] **Step 1: Write the failing test for `plot` argument parsing and dispatch**
+
+Create `tests/test_cli.py`:
+
+```python
+import prettymaps.cli as cli
+
+
+def test_plot_command_calls_plot_with_parsed_args(monkeypatch):
+    calls = []
+
+    def fake_plot(query, preset=None, save_as=None, figsize=None):
+        calls.append(
+            {"query": query, "preset": preset, "save_as": save_as, "figsize": figsize}
+        )
+
+    monkeypatch.setattr(cli, "_plot", fake_plot)
+
+    cli.main(["plot", "Bom Fim, Porto Alegre, Brasil", "-o", "out.png"])
+
+    assert calls == [
+        {
+            "query": "Bom Fim, Porto Alegre, Brasil",
+            "preset": "default",
+            "save_as": "out.png",
+            "figsize": (11.7, 11.7),
+        }
+    ]
+
+
+def test_plot_command_with_preset_and_size(monkeypatch):
+    calls = []
+
+    def fake_plot(query, preset=None, save_as=None, figsize=None):
+        calls.append(
+            {"query": query, "preset": preset, "save_as": save_as, "figsize": figsize}
+        )
+
+    monkeypatch.setattr(cli, "_plot", fake_plot)
+
+    cli.main(
+        [
+            "plot",
+            "Rome, Italy",
+            "--preset",
+            "minimal",
+            "-o",
+            "rome.svg",
+            "--width",
+            "8",
+            "--height",
+            "10",
+        ]
+    )
+
+    assert calls == [
+        {
+            "query": "Rome, Italy",
+            "preset": "minimal",
+            "save_as": "rome.svg",
+            "figsize": (8.0, 10.0),
+        }
+    ]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_cli.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'prettymaps.cli'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `prettymaps/cli.py`:
+
+```python
+import argparse
+
+from .draw import plot as _plot
+from .draw import presets as _presets
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(prog="prettymaps")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    plot_parser = subparsers.add_parser("plot", help="Draw a map for a query")
+    plot_parser.add_argument("query", help="Place name, coordinates, or address")
+    plot_parser.add_argument(
+        "--preset", default="default", help="Preset name (see list-presets)"
+    )
+    plot_parser.add_argument(
+        "-o", "--output", required=True, help="Output file path (e.g. map.png)"
+    )
+    plot_parser.add_argument(
+        "--width", type=float, default=11.7, help="Figure width in inches"
+    )
+    plot_parser.add_argument(
+        "--height", type=float, default=11.7, help="Figure height in inches"
+    )
+
+    subparsers.add_parser("list-presets", help="List available preset names")
+
+    return parser
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+
+    if args.command == "plot":
+        _plot(
+            args.query,
+            preset=args.preset,
+            save_as=args.output,
+            figsize=(args.width, args.height),
+        )
+    elif args.command == "list-presets":
+        for name in _presets()["preset"]:
+            print(name)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_cli.py -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git checkout -b add-prettymaps-cli
+git add prettymaps/cli.py tests/test_cli.py
+git commit -m "feat: add prettymaps plot CLI command"
+```
+
+---
+
+### Task 3: CLI `list-presets` command
+
+**Files:**
+- Modify: `tests/test_cli.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_cli.py`:
+
+```python
+def test_list_presets_prints_preset_names(capsys):
+    cli.main(["list-presets"])
+
+    out = capsys.readouterr().out
+    assert "default" in out.splitlines()
+```
+
+- [ ] **Step 2: Run test to verify it fails or passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_cli.py::test_list_presets_prints_preset_names -v`
+Expected: PASS already, since `list-presets` was implemented together with the parser in Task 2. This step exists to lock in the behavior with a dedicated test — if it fails, the `list-presets` branch in `main()` has a bug; re-check the `elif args.command == "list-presets":` block in `prettymaps/cli.py`.
+
+- [ ] **Step 3: Run the full CLI test file**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_cli.py -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_cli.py
+git commit -m "test: lock in list-presets CLI output"
+```
+
+---
+
+### Task 4: Register console script and verify end-to-end
+
+**Files:**
+- Modify: `setup.py`
+
+- [ ] **Step 1: Add the entry point**
+
+In `setup.py`, add `entry_points` to the `setup()` call (after `package_data`):
+
+```python
+    package_data={"prettymaps": ["presets/*.json"]},
+    entry_points={"console_scripts": ["prettymaps=prettymaps.cli:main"]},
+    python_requires=">=3.12",
+```
+
+- [ ] **Step 2: Reinstall editable to pick up the entry point**
+
+Run: `.venv/Scripts/python.exe -m pip install -e .`
+Expected: reinstalls, creates `.venv/Scripts/prettymaps.exe`
+
+- [ ] **Step 3: Verify the console script works**
+
+Run: `.venv/Scripts/prettymaps.exe list-presets`
+Expected: prints one preset name per line, including `default`
+
+- [ ] **Step 4: Verify plot end-to-end against a real query (manual, network-dependent)**
+
+Run: `.venv/Scripts/prettymaps.exe plot "Bom Fim, Porto Alegre, Brasil" -o /tmp/test-map.png`
+Expected: no errors, `/tmp/test-map.png` exists and is a non-empty PNG. This hits OpenStreetMap over the network — same as the existing tests in `tests/test.py`, no mocking.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add setup.py
+git commit -m "feat: register prettymaps console script"
+```
+
+---
+
+### Task 5: Global Claude Code skill
+
+**Files:**
+- Create: `C:\Users\tomma\.claude\skills\prettymaps\SKILL.md`
+
+- [ ] **Step 1: Write the skill file**
+
+Create `C:\Users\tomma\.claude\skills\prettymaps\SKILL.md`:
+
+```markdown
+---
+name: prettymaps
+description: Generate a decorative map (PNG/SVG) for a place using the local prettymaps CLI. Use when the user asks to draw, generate, or create a map, a city map poster, or mentions prettymaps.
+---
+
+# prettymaps
+
+Generates pretty maps from OpenStreetMap data via the local `prettymaps` CLI,
+installed in a dedicated venv inside the `prettymaps` repo.
+
+## Running the CLI
+
+Always call the CLI by its absolute path — this works regardless of the
+calling project's working directory or PATH:
+
+```
+G:/Documenti/GitHub/prettymaps/.venv/Scripts/prettymaps.exe <command> ...
+```
+
+## Commands
+
+- `list-presets` — prints available preset names.
+- `plot QUERY -o OUTPUT [--preset NAME] [--width N] [--height N]` — draws a
+  map for `QUERY` (a place name, address, or "lat, lon") and saves it to
+  `OUTPUT` (extension controls format, e.g. `.png`, `.svg`). `--preset`
+  defaults to `default`; run `list-presets` first if the user names a style
+  you're unsure about. `--width`/`--height` are in inches, default 11.7x11.7.
+
+## Workflow
+
+1. Ask the user for the place/query if not given.
+2. Pick an output path (scratchpad directory if the user doesn't specify one).
+3. Run the `plot` command via Bash using the absolute path above.
+4. Send the resulting image to the user with `SendUserFile`.
+
+## Example
+
+```bash
+G:/Documenti/GitHub/prettymaps/.venv/Scripts/prettymaps.exe plot "Rome, Italy" -o rome.png --preset default
+```
+```
+
+- [ ] **Step 2: Verify the skill is picked up**
+
+Run (from any directory, in a new Claude Code session): ask "generate a prettymaps map of Rome" and confirm Claude invokes the skill and calls the CLI by absolute path.
+Expected: the skill triggers, the CLI runs, an image file is produced and sent back.
+
+- [ ] **Step 3: Commit the plan/skill reference in the repo (optional doc trail)**
+
+No repo file changes are required for this task since the skill lives outside the repo in `~/.claude/skills/`. Nothing to commit here.
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: CLI `plot`/`list-presets` (Tasks 2-3), venv (Task 1), console-script install (Task 4), global skill (Task 5) — all spec sections covered.
+- Out-of-scope items from the spec (pixel sizing, preset editing, PyPI publishing, skill config layer) are intentionally not tasked.
+- `_plot`/`_presets` names in `cli.py` are used consistently between Task 2's implementation and its tests.

--- a/docs/superpowers/specs/2026-08-23-cli-and-skill-design.md
+++ b/docs/superpowers/specs/2026-08-23-cli-and-skill-design.md
@@ -1,0 +1,52 @@
+# prettymaps CLI + global Claude skill
+
+## Goal
+
+Use prettymaps from the terminal and from any Claude Code project, without touching Python code by hand each time.
+
+## Scope
+
+1. A minimal CLI inside the `prettymaps` package.
+2. A dedicated venv for the repo.
+3. A global Claude Code skill that drives the CLI from any project.
+
+## 1. CLI
+
+New file `prettymaps/cli.py`, using `argparse` (stdlib, no new dependency).
+
+Commands:
+
+- `prettymaps plot QUERY [--preset NAME] [-o FILE] [--width N] [--height N]`
+  Calls `prettymaps.plot(query, preset=preset, save_as=output, figsize=(width, height))`.
+  Defaults: `preset="default"`, `-o` required, `--width`/`--height` default to the library default `(11.7, 11.7)` inches (native figsize units, no pixel conversion).
+- `prettymaps list-presets`
+  Prints one preset name per line from `prettymaps.presets()["preset"]`.
+
+Errors (bad query, network failure, missing preset) propagate as-is — no custom retry/handling layer.
+
+Entry point registered in `setup.py`:
+
+```python
+entry_points={"console_scripts": ["prettymaps=prettymaps.cli:main"]}
+```
+
+## 2. Environment
+
+- `.venv` created inside the repo root (`python -m venv .venv`).
+- `pip install -e .` run inside that venv, so `prettymaps` CLI is available as `.venv/Scripts/prettymaps.exe` (Windows) and importable for development.
+- No global/system Python install touched.
+
+## 3. Global Claude Code skill
+
+- Location: `~/.claude/skills/prettymaps/SKILL.md` (global, available in every project).
+- Trigger: user asks to generate/draw a map, mentions "prettymaps", or runs `/prettymaps`.
+- Behavior: the skill's instructions tell Claude to invoke the CLI via Bash using the **absolute path** to the venv's Python/executable in this repo (e.g. `G:/Documenti/GitHub/prettymaps/.venv/Scripts/prettymaps.exe`), so it works regardless of the calling project's working directory or PATH.
+- After generating a map, use `SendUserFile` to show the resulting image to the user.
+- No wrapper scripts, no extra abstraction — the skill calls the CLI directly.
+
+## Out of scope (explicitly not building)
+
+- Pixel-based sizing (figsize stays in inches, matching the library's native API).
+- Preset editing/creation from the CLI.
+- Packaging/publishing prettymaps to PyPI.
+- Any config file or settings layer for the skill.

--- a/prettymaps/cli.py
+++ b/prettymaps/cli.py
@@ -22,6 +22,11 @@ def build_parser():
     plot_parser.add_argument(
         "--height", type=float, default=11.7, help="Figure height in inches"
     )
+    plot_parser.add_argument(
+        "--no-credit",
+        action="store_true",
+        help="Omit the OpenStreetMap/prettymaps credit box from the image",
+    )
 
     subparsers.add_parser("list-presets", help="List available preset names")
 
@@ -37,6 +42,7 @@ def main(argv=None):
             preset=args.preset,
             save_as=args.output,
             figsize=(args.width, args.height),
+            credit=False if args.no_credit else {},
         )
     elif args.command == "list-presets":
         for name in _presets()["preset"]:

--- a/prettymaps/cli.py
+++ b/prettymaps/cli.py
@@ -27,6 +27,24 @@ def build_parser():
         action="store_true",
         help="Omit the OpenStreetMap/prettymaps credit box from the image",
     )
+    plot_parser.add_argument(
+        "--radius",
+        type=float,
+        default=None,
+        help="Radius in meters around the query point, instead of the OSM boundary",
+    )
+    plot_parser.add_argument(
+        "--circle",
+        action="store_true",
+        default=None,
+        help="With --radius, use a circular boundary instead of a square one",
+    )
+    plot_parser.add_argument(
+        "--dilate",
+        type=float,
+        default=None,
+        help="Expand (or shrink, if negative) the boundary by this many meters",
+    )
 
     subparsers.add_parser("list-presets", help="List available preset names")
 
@@ -43,6 +61,9 @@ def main(argv=None):
             save_as=args.output,
             figsize=(args.width, args.height),
             credit=False if args.no_credit else {},
+            radius=args.radius,
+            circle=args.circle,
+            dilate=args.dilate,
         )
     elif args.command == "list-presets":
         for name in _presets()["preset"]:

--- a/prettymaps/cli.py
+++ b/prettymaps/cli.py
@@ -1,0 +1,47 @@
+import argparse
+
+from .draw import plot as _plot
+from .draw import presets as _presets
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(prog="prettymaps")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    plot_parser = subparsers.add_parser("plot", help="Draw a map for a query")
+    plot_parser.add_argument("query", help="Place name, coordinates, or address")
+    plot_parser.add_argument(
+        "--preset", default="default", help="Preset name (see list-presets)"
+    )
+    plot_parser.add_argument(
+        "-o", "--output", required=True, help="Output file path (e.g. map.png)"
+    )
+    plot_parser.add_argument(
+        "--width", type=float, default=11.7, help="Figure width in inches"
+    )
+    plot_parser.add_argument(
+        "--height", type=float, default=11.7, help="Figure height in inches"
+    )
+
+    subparsers.add_parser("list-presets", help="List available preset names")
+
+    return parser
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+
+    if args.command == "plot":
+        _plot(
+            args.query,
+            preset=args.preset,
+            save_as=args.output,
+            figsize=(args.width, args.height),
+        )
+    elif args.command == "list-presets":
+        for name in _presets()["preset"]:
+            print(name)
+
+
+if __name__ == "__main__":
+    main()

--- a/prettymaps/draw.py
+++ b/prettymaps/draw.py
@@ -197,9 +197,12 @@ def graph_to_shapely(gdf: gp.GeoDataFrame, width: float = 1.0) -> BaseGeometry:
             return np.nan
 
     # Annotate GeoDataFrame with the width for each highway type
-    gdf["width"] = (
-        gdf["highway"].map(highway_to_width) if type(width) == dict else width
-    )
+    if type(width) == dict:
+        gdf["width"] = (
+            gdf["highway"].map(highway_to_width) if "highway" in gdf.columns else np.nan
+        )
+    else:
+        gdf["width"] = width
 
     # Remove rows with inexistent width
     gdf.drop(gdf[gdf.width.isna()].index, inplace=True)

--- a/prettymaps/fetch.py
+++ b/prettymaps/fetch.py
@@ -592,22 +592,26 @@ def unified_osm_request(
 
     # Initialize the result dictionary
     gdfs = {}
-    ## Read layers from cache
-    # for layer, kwargs in layers_dict.items():
-    #    gdf = read_from_cache(perimeter, layers_dict[layer])
-    #    if gdf is not None:
-    #        gdfs[layer] = gdf
+    # Read layers from cache (skips network fetch entirely on a hit)
+    for layer, kwargs in layers_dict.items():
+        if layer == "perimeter":
+            continue
+        cached = read_from_cache(perimeter, kwargs)
+        if cached is not None:
+            gdfs[layer] = cached
 
     # Combine all tags into a single dictionary for a unified request
     combined_tags = merge_tags(
         {layer: kwargs for layer, kwargs in layers_dict.items() if layer not in gdfs}
     )
 
-    # Fetch all features in one request
-    try:
-        all_features = ox.features.features_from_polygon(bbox, tags=combined_tags)
-    except Exception as e:
-        all_features = GeoDataFrame(geometry=[])
+    # Fetch all features in one request (skip if every tag-based layer was cached)
+    all_features = GeoDataFrame(geometry=[])
+    if combined_tags:
+        try:
+            all_features = ox.features.features_from_polygon(bbox, tags=combined_tags)
+        except Exception as e:
+            all_features = GeoDataFrame(geometry=[])
 
     # Split the features into separate GeoDataFrames based on the layers_dict
     for layer, kwargs in layers_dict.items():
@@ -668,6 +672,8 @@ def unified_osm_request(
                         layer_tags = kwargs.get("tags")
                         gdf = gp.GeoDataFrame(geometry=[], crs=perimeter.crs)
                         for key, value in layer_tags.items():
+                            if key not in all_features.columns:
+                                continue
                             if isinstance(value, bool) and value:
                                 filtered_features = all_features[
                                     ~pd.isna(all_features[key])
@@ -688,7 +694,8 @@ def unified_osm_request(
             gdf.geometry = gdf.geometry.intersection(perimeter_with_tolerance)
             gdf.drop(gdf[gdf.geometry.is_empty].index, inplace=True)
             gdfs[layer] = gdf
-            # write_to_cache(perimeter, gdf, layers_dict[layer])
+            if layer != "perimeter":
+                write_to_cache(perimeter, gdf, kwargs)
         except Exception as e:
             # print(f"Error fetching {layer}: {e}")
             gdfs[layer] = GeoDataFrame(geometry=[])

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,6 @@ setup(
     ],
     package_dir={"prettymaps": "prettymaps"},
     package_data={"prettymaps": ["presets/*.json"]},
+    entry_points={"console_scripts": ["prettymaps=prettymaps.cli:main"]},
     python_requires=">=3.12",
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,58 @@
+import prettymaps.cli as cli
+
+
+def test_plot_command_calls_plot_with_parsed_args(monkeypatch):
+    calls = []
+
+    def fake_plot(query, preset=None, save_as=None, figsize=None):
+        calls.append(
+            {"query": query, "preset": preset, "save_as": save_as, "figsize": figsize}
+        )
+
+    monkeypatch.setattr(cli, "_plot", fake_plot)
+
+    cli.main(["plot", "Bom Fim, Porto Alegre, Brasil", "-o", "out.png"])
+
+    assert calls == [
+        {
+            "query": "Bom Fim, Porto Alegre, Brasil",
+            "preset": "default",
+            "save_as": "out.png",
+            "figsize": (11.7, 11.7),
+        }
+    ]
+
+
+def test_plot_command_with_preset_and_size(monkeypatch):
+    calls = []
+
+    def fake_plot(query, preset=None, save_as=None, figsize=None):
+        calls.append(
+            {"query": query, "preset": preset, "save_as": save_as, "figsize": figsize}
+        )
+
+    monkeypatch.setattr(cli, "_plot", fake_plot)
+
+    cli.main(
+        [
+            "plot",
+            "Rome, Italy",
+            "--preset",
+            "minimal",
+            "-o",
+            "rome.svg",
+            "--width",
+            "8",
+            "--height",
+            "10",
+        ]
+    )
+
+    assert calls == [
+        {
+            "query": "Rome, Italy",
+            "preset": "minimal",
+            "save_as": "rome.svg",
+            "figsize": (8.0, 10.0),
+        }
+    ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,16 @@ import prettymaps.cli as cli
 def test_plot_command_calls_plot_with_parsed_args(monkeypatch):
     calls = []
 
-    def fake_plot(query, preset=None, save_as=None, figsize=None, credit=None):
+    def fake_plot(
+        query,
+        preset=None,
+        save_as=None,
+        figsize=None,
+        credit=None,
+        radius=None,
+        circle=None,
+        dilate=None,
+    ):
         calls.append(
             {
                 "query": query,
@@ -12,6 +21,9 @@ def test_plot_command_calls_plot_with_parsed_args(monkeypatch):
                 "save_as": save_as,
                 "figsize": figsize,
                 "credit": credit,
+                "radius": radius,
+                "circle": circle,
+                "dilate": dilate,
             }
         )
 
@@ -26,6 +38,9 @@ def test_plot_command_calls_plot_with_parsed_args(monkeypatch):
             "save_as": "out.png",
             "figsize": (11.7, 11.7),
             "credit": {},
+            "radius": None,
+            "circle": None,
+            "dilate": None,
         }
     ]
 
@@ -33,7 +48,16 @@ def test_plot_command_calls_plot_with_parsed_args(monkeypatch):
 def test_plot_command_with_preset_and_size(monkeypatch):
     calls = []
 
-    def fake_plot(query, preset=None, save_as=None, figsize=None, credit=None):
+    def fake_plot(
+        query,
+        preset=None,
+        save_as=None,
+        figsize=None,
+        credit=None,
+        radius=None,
+        circle=None,
+        dilate=None,
+    ):
         calls.append(
             {
                 "query": query,
@@ -41,6 +65,9 @@ def test_plot_command_with_preset_and_size(monkeypatch):
                 "save_as": save_as,
                 "figsize": figsize,
                 "credit": credit,
+                "radius": radius,
+                "circle": circle,
+                "dilate": dilate,
             }
         )
 
@@ -68,14 +95,42 @@ def test_plot_command_with_preset_and_size(monkeypatch):
             "save_as": "rome.svg",
             "figsize": (8.0, 10.0),
             "credit": {},
+            "radius": None,
+            "circle": None,
+            "dilate": None,
         }
     ]
+
+
+def test_plot_command_with_radius_circle_dilate(monkeypatch):
+    calls = []
+
+    def fake_plot(query, preset=None, save_as=None, figsize=None, credit=None, radius=None, circle=None, dilate=None):
+        calls.append({"radius": radius, "circle": circle, "dilate": dilate})
+
+    monkeypatch.setattr(cli, "_plot", fake_plot)
+
+    cli.main(
+        [
+            "plot",
+            "Rome, Italy",
+            "-o",
+            "rome.png",
+            "--radius",
+            "500",
+            "--circle",
+            "--dilate",
+            "10",
+        ]
+    )
+
+    assert calls == [{"radius": 500.0, "circle": True, "dilate": 10.0}]
 
 
 def test_plot_command_with_no_credit_flag(monkeypatch):
     calls = []
 
-    def fake_plot(query, preset=None, save_as=None, figsize=None, credit=None):
+    def fake_plot(query, preset=None, save_as=None, figsize=None, credit=None, **kwargs):
         calls.append(credit)
 
     monkeypatch.setattr(cli, "_plot", fake_plot)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,3 +56,10 @@ def test_plot_command_with_preset_and_size(monkeypatch):
             "figsize": (8.0, 10.0),
         }
     ]
+
+
+def test_list_presets_prints_preset_names(capsys):
+    cli.main(["list-presets"])
+
+    out = capsys.readouterr().out
+    assert "default" in out.splitlines()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,9 +4,15 @@ import prettymaps.cli as cli
 def test_plot_command_calls_plot_with_parsed_args(monkeypatch):
     calls = []
 
-    def fake_plot(query, preset=None, save_as=None, figsize=None):
+    def fake_plot(query, preset=None, save_as=None, figsize=None, credit=None):
         calls.append(
-            {"query": query, "preset": preset, "save_as": save_as, "figsize": figsize}
+            {
+                "query": query,
+                "preset": preset,
+                "save_as": save_as,
+                "figsize": figsize,
+                "credit": credit,
+            }
         )
 
     monkeypatch.setattr(cli, "_plot", fake_plot)
@@ -19,6 +25,7 @@ def test_plot_command_calls_plot_with_parsed_args(monkeypatch):
             "preset": "default",
             "save_as": "out.png",
             "figsize": (11.7, 11.7),
+            "credit": {},
         }
     ]
 
@@ -26,9 +33,15 @@ def test_plot_command_calls_plot_with_parsed_args(monkeypatch):
 def test_plot_command_with_preset_and_size(monkeypatch):
     calls = []
 
-    def fake_plot(query, preset=None, save_as=None, figsize=None):
+    def fake_plot(query, preset=None, save_as=None, figsize=None, credit=None):
         calls.append(
-            {"query": query, "preset": preset, "save_as": save_as, "figsize": figsize}
+            {
+                "query": query,
+                "preset": preset,
+                "save_as": save_as,
+                "figsize": figsize,
+                "credit": credit,
+            }
         )
 
     monkeypatch.setattr(cli, "_plot", fake_plot)
@@ -54,8 +67,22 @@ def test_plot_command_with_preset_and_size(monkeypatch):
             "preset": "minimal",
             "save_as": "rome.svg",
             "figsize": (8.0, 10.0),
+            "credit": {},
         }
     ]
+
+
+def test_plot_command_with_no_credit_flag(monkeypatch):
+    calls = []
+
+    def fake_plot(query, preset=None, save_as=None, figsize=None, credit=None):
+        calls.append(credit)
+
+    monkeypatch.setattr(cli, "_plot", fake_plot)
+
+    cli.main(["plot", "Rome, Italy", "-o", "rome.png", "--no-credit"])
+
+    assert calls == [False]
 
 
 def test_list_presets_prints_preset_names(capsys):


### PR DESCRIPTION
## Summary
- Guard missing `highway` column in `graph_to_shapely` and the tag-filter loop in `unified_osm_request`, so a partial/empty Overpass response for one layer no longer crashes the whole `plot` (matches upstream marceloprates/prettymaps#154).
- Re-enable the disk cache for fetched layers (was fully commented out in `unified_osm_request`), so repeat runs for the same place skip the network fetch entirely instead of re-hitting Overpass every time.

Root cause context: fetch latency is dominated by Overpass API throttling (confirmed against upstream #22, #150), not something fixable here — these changes address the two crash bugs plus the dead caching that was making every run pay full network cost regardless.

## Test plan
- [x] Ran `plot "Vatican City" --preset default` end-to-end after a full cache wipe: no crash, image produced, `prettymaps_cache/` populated with layer entries.
- [x] Verified the previous `KeyError: 'highway'` crash (seen in `draw.py` and in `fetch.py`'s tag-filter loop) no longer reproduces.