### PR TITLE
Use OS-independent path for generated figure

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import logging
 from matplotlib import pyplot as plt
 import sys
 import os
+import tempfile
 import io
 
 
@@ -10,7 +11,7 @@ def download_svg():
     """
     Creates additional map in SVG format
     """
-    fig_path = "/tmp/generated_map_download.svg"
+    fig_path = os.path.join(tempfile.gettempdir(), "generated_map.svg")
     plt.savefig(fig_path, format="svg", bbox_inches="tight", dpi=150)
     return fig_path
 
@@ -174,7 +175,7 @@ with cols[1]:
             st.session_state.last_image = buf
 
             # Save the figure to a file
-            fig_path = "/tmp/generated_map.png"
+            fig_path = os.path.join(tempfile.gettempdir(), "generated_map.png")
             with open(fig_path, "wb") as f:
                 f.write(st.session_state.last_image.getbuffer())
 


### PR DESCRIPTION
## Fix generated map path on Windows

### Problem

When running PrettyMaps on Windows, a `FileNotFoundError` occurs when trying to open the generated map file:

```text
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/generated_map.png'
```

The error occurs in `app.py` when opening the generated file:

```python
with open(fig_path, "wb") as f:
```

The hardcoded `/tmp/` path is Unix-specific and does not work correctly on Windows.

### Solution

Replaced the hardcoded path with an OS-independent temporary directory:

```python
fig_path = os.path.join(tempfile.gettempdir(), "generated_map.png")
```

This uses the appropriate temporary directory for the operating system.

### Result

The map generation and download functionality now works correctly on Windows while remaining compatible with Unix-based systems.
